### PR TITLE
Bugfix. The program crashes due to a Null Pointer Exception.

### DIFF
--- a/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/CInvokeAssign.java
+++ b/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/CInvokeAssign.java
@@ -1,0 +1,29 @@
+package com.example.demo.WorkflowExecution.WorkflowTasks;
+
+import com.example.demo.Network.IMessage;
+import com.example.demo.WorkflowParser.WorkflowParserObjects.CInvokeAssignTask;
+import com.example.demo.WorkflowParser.WorkflowParserObjects.IWorkflow;
+
+import java.util.Queue;
+
+public class CInvokeAssign extends IBaseTaskAction {
+
+    private final CInvokeAssignTask mTask;
+
+    CInvokeAssign(IWorkflow pWorkflow, CInvokeAssignTask pTask) {
+        super(pWorkflow);
+        mTask = pTask;
+    }
+
+    @Override
+    public void accept(IMessage iMessage) {
+
+    }
+
+    @Override
+    public Boolean apply(Queue<ITaskAction> iTaskActions) {
+        mTask.target().setValue(mTask.jsonSource());
+
+        return false;
+    }
+}

--- a/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/EWorkflowTaskFactory.java
+++ b/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/EWorkflowTaskFactory.java
@@ -1,13 +1,7 @@
 package com.example.demo.WorkflowExecution.WorkflowTasks;
 
 
-import com.example.demo.WorkflowParser.WorkflowParserObjects.CInvokeServiceTask;
-import com.example.demo.WorkflowParser.WorkflowParserObjects.CWorkflow;
-import com.example.demo.WorkflowParser.WorkflowParserObjects.CAssignTask;
-import com.example.demo.WorkflowParser.WorkflowParserObjects.CInvokeServiceTask;
-
-import com.example.demo.WorkflowParser.WorkflowParserObjects.ITask;
-import com.example.demo.WorkflowParser.WorkflowParserObjects.IWorkflow;
+import com.example.demo.WorkflowParser.WorkflowParserObjects.*;
 import org.springframework.lang.NonNull;
 
 public enum EWorkflowTaskFactory {
@@ -23,6 +17,9 @@ public enum EWorkflowTaskFactory {
 
             case ASSIGN:
                 return new CAssign(pWorkflow, (CAssignTask) pTask.raw());
+
+            case INVOKEASSIGN:
+                return new CInvokeAssign(pWorkflow, (CInvokeAssignTask) pTask.raw());
 
             default:
                 throw new RuntimeException("Chosen task is unknown!");

--- a/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/EWorkflowTaskType.java
+++ b/src/main/java/com/example/demo/WorkflowExecution/WorkflowTasks/EWorkflowTaskType.java
@@ -4,6 +4,7 @@ public enum EWorkflowTaskType {
 
     INVOKESERVICE,
     ASSIGN,
+    INVOKEASSIGN,
     SWITCH
 
 }

--- a/src/main/java/com/example/demo/WorkflowParser/EWorkflowParser.java
+++ b/src/main/java/com/example/demo/WorkflowParser/EWorkflowParser.java
@@ -229,7 +229,7 @@ public enum EWorkflowParser {
      * @param assignTo
      * @return
      */
-    public CAssignTask buildAssignTask(String assignTo) {
+    public CInvokeAssignTask buildAssignTask(String assignTo) {
         String lPrefix = assignTo.split("\\.")[0];
         String lVariable = assignTo.split("\\.")[1];
 
@@ -243,7 +243,7 @@ public enum EWorkflowParser {
                     .orElse("FALSE");
 
             if (!variableKey.equals("FALSE")) {
-                return new CAssignTask(null, variables.get(variableKey));
+                return new CInvokeAssignTask(variables.get(variableKey));
             } else {
                 throw new WorkflowParseException("Variable could not be found. It was probably not created.");
             }

--- a/src/main/java/com/example/demo/WorkflowParser/WorkflowParserObjects/CInvokeAssignTask.java
+++ b/src/main/java/com/example/demo/WorkflowParser/WorkflowParserObjects/CInvokeAssignTask.java
@@ -1,0 +1,46 @@
+package com.example.demo.WorkflowParser.WorkflowParserObjects;
+
+import com.example.demo.WorkflowExecution.WorkflowTasks.EWorkflowTaskType;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.lang.NonNull;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class CInvokeAssignTask implements ITask {
+
+    private final AtomicReference<IVariable> mTargetReference;
+    private final EWorkflowTaskType mTaskType;
+    private JsonNode mJsonSource;
+
+    public CInvokeAssignTask(IVariable pTargetReference) {
+        this.mTargetReference = new AtomicReference<>(pTargetReference);
+
+        mTaskType = EWorkflowTaskType.INVOKEASSIGN;
+    }
+
+    @NonNull
+    @Override
+    public Object raw() {
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public EWorkflowTaskType getWorkflowType() {
+        return mTaskType;
+    }
+
+    public void setJsonSource(JsonNode pJsonSource) {
+        mJsonSource = pJsonSource;
+    }
+
+    @NonNull
+    public IVariable target() {
+        return mTargetReference.get();
+    }
+
+    @NonNull
+    public JsonNode jsonSource() {
+        return mJsonSource;
+    }
+}

--- a/src/main/java/com/example/demo/WorkflowParser/WorkflowParserObjects/CInvokeServiceTask.java
+++ b/src/main/java/com/example/demo/WorkflowParser/WorkflowParserObjects/CInvokeServiceTask.java
@@ -14,7 +14,7 @@ public class CInvokeServiceTask implements ITask {
     private final Api mApi;
     private boolean mIsValidatorRequired;
     private final EWorkflowTaskType mTaskType;
-    private CAssignTask mAssignTask;
+    private CInvokeAssignTask mAssignTask;
 
     public CInvokeServiceTask(String pTitle, int pMethodIndex, Api pApi) {
         this.mTitle = pTitle;
@@ -32,7 +32,7 @@ public class CInvokeServiceTask implements ITask {
         this.mIsValidatorRequired = pIsValidatorRequired;
     }
 
-    public void setAssignTask(CAssignTask pAssignTask) {
+    public void setAssignTask(CInvokeAssignTask pAssignTask) {
         this.mAssignTask = pAssignTask;
     }
 
@@ -65,7 +65,7 @@ public class CInvokeServiceTask implements ITask {
         return mIsValidatorRequired;
     }
 
-    public CAssignTask assignTask() {
+    public CInvokeAssignTask assignTask() {
         return mAssignTask;
     }
 }


### PR DESCRIPTION
Reference: Issue: *Fix Workflow-Execution* fixes #14
As a solution a second Assign activity was created, which contains only the reference to the target variable and gets a JSON Value.
Various other classes had to be extended or changed for this function.


